### PR TITLE
Include Installer's dependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,12 @@
     "lambda",
     "nodejs"
   ],
+  "dependencies": [
+    "phantomjs": "^2.1.7",
+    "q": "^1.4.1",
+    "request": "^2.74.0",
+    "underscore": "^1.8.3"
+  ],
   "author": "Mike Lyons <mdl0394@gmail.com>",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
When doing `npm install --save lambda-phantomjs-installer`, this module's dependencies:
- `phantomjs`
- `q`
- `request`
- `underscore`

...are not automatically installed because they are not defined in `package.json`.

Any lambda functions using this module will fail without manual user intervention to install these. 
Please merge and update npm! 🙏
